### PR TITLE
feat: structure final agreement prompt

### DIFF
--- a/__tests__/ai-negotiation.test.js
+++ b/__tests__/ai-negotiation.test.js
@@ -49,4 +49,24 @@ describe('AI negotiation agents', () => {
     expect(context).toContain('proposal from Bob');
     expect(moderator.negotiationRounds).toHaveLength(1);
   });
+
+  test('AIModerator uses structured prompt for final agreement', async () => {
+    mockCreate.mockResolvedValue({ choices: [{ message: { content: 'final' } }] });
+    const advocate1 = new AIAdvocate('Alice', { objectives: 'o1', mustHaves: 'm1', constraints: 'c1' }, 'Dishwashing');
+    const advocate2 = new AIAdvocate('Bob', { objectives: 'o2', mustHaves: 'm2', constraints: 'c2' }, 'Dishwashing');
+    const moderator = new AIModerator('Dishwashing', advocate1, advocate2);
+    moderator.negotiationRounds.push({
+      proposal1: 'p1',
+      proposal2: 'p2',
+      moderation: 'm1',
+      timestamp: Date.now()
+    });
+
+    await moderator.generateFinalAgreement();
+    expect(mockCreate).toHaveBeenCalled();
+    const call = mockCreate.mock.calls[0][0];
+    const userPrompt = call.messages[1].content;
+    expect(userPrompt).toContain('<h1>Final Dishwashing Agreement</h1>');
+    expect(userPrompt).toContain('short plain-text summary');
+  });
 });

--- a/ai-negotiation.js
+++ b/ai-negotiation.js
@@ -174,13 +174,32 @@ Please moderate this round by:
             .map((round, index) => `Round ${index + 1}:\n- ${this.advocate1.userName}: ${round.proposal1}\n- ${this.advocate2.userName}: ${round.proposal2}\n- Moderator: ${round.moderation}`)
             .join('\n\n');
 
-        const prompt = `Based on the complete negotiation below, generate a final agreement:
+        const prompt = `Based on the complete negotiation below, draft the final agreement.
 
 ${negotiationSummary}
 
-Please provide:
-1. A clear, actionable final agreement in HTML format
-2. A brief summary of how this agreement was reached (for transparency)
+Return a cleanly formatted response that contains:
+
+1. An HTML code block:
+   - Start with <h1>Final ${this.topic} Agreement</h1>
+   - Use <p> elements for each numbered clause in the form <p><strong>1. Clause Title:</strong> Clause text.</p>
+   - Use <h2> subheadings where helpful.
+   - When listing bullet points, use <ul> and <li> with <strong> labels.
+   - Ensure the HTML is properly indented and valid.
+
+2. A short plain-text summary (outside the code block) explaining how the agreement was reached.
+
+Example structure:
+
+\`\`\`html
+<h1>Final ${this.topic} Agreement</h1>
+<p><strong>1. Clause Name:</strong> Clause details.</p>
+<p><strong>2. Clause Name:</strong> Clause details.</p>
+<h2>Guiding Principles</h2>
+<ul>
+  <li><strong>Principle:</strong> Explanation.</li>
+</ul>
+\`\`\`
 
 The agreement should be specific, fair, and implementable by both parties.`;
 


### PR DESCRIPTION
## Summary
- refine final agreement prompt to enforce HTML structure and summary
- add test ensuring moderator includes structured prompt for final agreement

## Testing
- `npm test` *(fails: APIConnectionError, WebSocket issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a8704da1988330adb9b75907cd8eb5