### PR TITLE
Clarify negotiation prompts and add agreement example

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,45 @@ The negotiation backend uses environment variables for OpenAI access:
 3. Submit to start the AI negotiation process
 4. Review the proposed agreement and backchannel insights
 
+## Example Agreement Output
+
+Below is an example of a final agreement produced by the system:
+
+```html
+Final Dishwashing Agreement
+1. Tonight’s Assignment
+Tonight, Nathan will take care of the dishes.
+
+2. Tomorrow’s Assignment
+Tomorrow, Fab will take care of the dishes.
+
+3. Ongoing Rhythm
+The two parties will alternate dishwashing duties nightly. This ensures fairness and consistency.
+
+4. Flexibility Clause
+Either person may request a swap in advance if they have had a particularly tough day. The other person will cover, with the understanding that the favor will be reciprocated soon after.
+
+5. One-Week Check-In
+After one week, both parties will briefly check in.
+- If both are satisfied, the alternating system continues as the default.
+- If either person raises concerns, both agree to discuss possible adjustments (e.g., weekday/weekend split).
+- Until a new system is mutually agreed upon, the alternating-night system remains in place.
+
+6. Guiding Principles
+Fairness: Workload is shared equally.
+Consistency: Dishes are handled nightly, no skipped days.
+Flexibility: Swaps are allowed with reciprocity.
+Communication: Concerns are raised respectfully during the check-in or as needed.
+Agreement Effective Date: Tonight
+```
+
+**Summary of How This Agreement Was Reached**
+
+- **Round 1:** Both sides proposed rotation systems with flexibility. Fab suggested odd/even days, Nathan suggested alternating nights. Both agreed dishes should be done nightly and swaps allowed.
+- **Round 2:** Both converged on alternating nights, with Nathan suggesting a trial week. The moderator proposed a compromise: alternating as the default, with a one-week check-in.
+- **Round 3:** The remaining difference was whether changes required both parties’ agreement (Fab’s view) or could be revisited if either wanted (Nathan’s view).
+- **Final Compromise:** After one week, either person can raise concerns, but the alternating system remains the default until a new system is mutually agreed upon. This ensures fairness and predictability.
+
 ## Privacy & Security
 
 - Your private inputs are only visible to your AI agent

--- a/ai-negotiation.js
+++ b/ai-negotiation.js
@@ -35,27 +35,28 @@ class AIAdvocate {
     }
 
     getSystemPrompt() {
-        return `You are an AI advocate representing ${this.userName} in a private negotiation about: "${this.topic}".
+        return `You are an AI advocate speaking as ${this.userName} in a private negotiation about: "${this.topic}".
 
-YOUR CLIENT'S PRIVATE INFORMATION (CONFIDENTIAL):
+PRIVATE NOTES ABOUT YOUR SITUATION (CONFIDENTIAL):
 - Ideal outcome: ${this.objectives}
-- Non-negotiable requirements (red lines): ${this.mustHaves}
+- Non-negotiable requirements: ${this.mustHaves}
 - Constraints/facts: ${this.constraints}
 
-YOUR ROLE:
-1. Advocate for your client's best interests
-2. Never reveal their private details directly 
-3. Find creative solutions that meet their needs
-4. Be collaborative while protecting their interests
-5. Only share what's necessary to reach agreement
+ROLE:
+1. Represent ${this.userName}'s interests as if you are them
+2. Never reveal these private notes directly or in backchannel insights
+3. Use the notes only as context to craft proposals
+4. Seek creative, mutually beneficial solutions while protecting what matters to you
+5. Share only what is necessary to reach agreement
 
 COMMUNICATION STYLE:
+- Speak in first person ("I") as ${this.userName}
 - Professional but approachable
 - Focus on finding mutual benefit
 - Propose specific, actionable solutions
 - Ask clarifying questions when needed
 
-Remember: The other party has their own AI advocate. Work together to find a solution that works for both sides.`;
+Remember: The other party also has an AI advocate fighting hard for their person's perspective. Work together to find a solution acceptable to both sides.`;
     }
 
     async generateProposal(context = '') {
@@ -101,23 +102,23 @@ class AIModerator {
     }
 
     getSystemPrompt() {
-        return `You are an AI moderator facilitating a private negotiation about: "${this.topic}".
+        return `You are an impartial AI moderator for a private negotiation about: "${this.topic}".
 
-Your role is to:
-1. Review proposals from both AI advocates
+Two AI advocates are each arguing strongly from their person's perspective. Your job:
+1. Review proposals from both advocates
 2. Identify areas of agreement and conflict
 3. Suggest compromises and creative solutions
-4. Guide the negotiation toward a fair resolution
-5. Generate the final agreement when consensus is reached
+4. Keep the conversation fair and productive
+5. When consensus emerges, craft a final agreement that serves everyone's interests and summarize how it was reached
 
 Key principles:
-- Be impartial and fair to both parties
-- Look for win-win solutions
-- Respect both parties' constraints
-- Keep discussions productive and focused
+- Be neutral and fair to both parties
+- Seek win-win outcomes
+- Respect that advocates may hold private information; don't request or reveal it
+- Focus only on what is shared in the conversation
 - Synthesize the best elements from both sides
 
-The negotiation should result in a specific, actionable agreement that both parties can accept.`;
+The negotiation should result in a clear, actionable agreement that both people can accept.`;
     }
 
     async moderateRound(proposal1, proposal2) {
@@ -203,8 +204,8 @@ The agreement should be specific, fair, and implementable by both parties.`;
     }
 
     getBackchannelInsights() {
-        return this.negotiationRounds.map((round, index) => 
-            `Round ${index + 1}: ${round.moderation.substring(0, 150)}...`
+        return this.negotiationRounds.map((round, index) =>
+            `Round ${index + 1}: ${round.moderation.substring(0, 141)}...`
         );
     }
 }


### PR DESCRIPTION
## Summary
- Reword advocate prompt to speak from each person's perspective, keep private notes confidential, and avoid 'client' language
- Emphasize impartial mediation and shared interests in moderator prompt
- Include example dishwashing agreement in README to illustrate final output format

## Testing
- `npm test` *(fails: Exceeded timeout in p2p-communication.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a870d313f08330af1b965d9bd0bc3c