### PR TITLE
Require mutual topic agreement before proceeding

### DIFF
--- a/index.html
+++ b/index.html
@@ -262,6 +262,7 @@
             userName: '',
             topic: '',
             topicAgreed: false,
+            partnerTopicAgreed: false,
             isCreator: false,
             connectionState: 'disconnected',
             partnerName: null,
@@ -700,10 +701,15 @@
                         topicInputEl.value = message.topic;
                     }
                     showNotification(`${message.sender} modified the topic`, 'info');
+                    sessionData.topicAgreed = false;
+                    sessionData.partnerTopicAgreed = false;
+                    updateTopicAgreementStatus();
                     saveSessionState(); // Save the updated topic
                     break;
                 case 'topicAgreed':
+                    sessionData.partnerTopicAgreed = true;
                     showNotification(`${message.sender} agreed to the topic!`, 'success');
+                    checkMutualTopicAgreement();
                     break;
                 case 'proceedToInputs':
                     proceedToPrivateInputs();
@@ -949,19 +955,13 @@
 
         document.getElementById('agreeTopic').addEventListener('click', async () => {
             sessionData.topicAgreed = true;
-            
-            // Send agreement to peer
+
             await sendMessage({
                 type: 'topicAgreed',
                 userName: sessionData.userName
             });
-            
-            // Send proceed signal
-            await sendMessage({
-                type: 'proceedToInputs'
-            });
-            
-            proceedToPrivateInputs();
+
+            checkMutualTopicAgreement();
         });
 
         document.getElementById('modifyTopic').addEventListener('click', () => {
@@ -974,11 +974,14 @@
                 alert('Please enter a modification');
                 return;
             }
-            
+
             // Update local topic
             sessionData.topic = modification;
             document.getElementById('proposedTopic').textContent = modification;
-            
+            sessionData.topicAgreed = false;
+            sessionData.partnerTopicAgreed = false;
+            updateTopicAgreementStatus();
+
             // Send to peer via WebSocket
             addDebugLog(`Sending topic modification: ${modification}`, 'info');
             const sent = await sendMessage({
@@ -1177,6 +1180,39 @@
             }
         }
 
+        function updateTopicAgreementStatus() {
+            const topicActions = document.getElementById('topicActions');
+            if (!topicActions) return;
+
+            let statusMsg = '';
+            if (sessionData.topicAgreed && !sessionData.partnerTopicAgreed) {
+                statusMsg = '<div class="mt-4 p-3 bg-yellow-50 border border-yellow-200 rounded-lg"><i class="fas fa-clock text-yellow-600 mr-2"></i>You agreed! Waiting for your partner to agree...</div>';
+            } else if (!sessionData.topicAgreed && sessionData.partnerTopicAgreed) {
+                statusMsg = '<div class="mt-4 p-3 bg-blue-50 border border-blue-200 rounded-lg"><i class="fas fa-check text-blue-600 mr-2"></i>Your partner agreed! Do you agree with this topic?</div>';
+            } else {
+                statusMsg = '';
+            }
+
+            const existingStatus = document.querySelector('.agreement-status');
+            if (existingStatus) existingStatus.remove();
+            if (statusMsg) {
+                const div = document.createElement('div');
+                div.className = 'agreement-status';
+                div.innerHTML = statusMsg;
+                topicActions.appendChild(div);
+            }
+        }
+
+        function checkMutualTopicAgreement() {
+            addDebugLog(`Agreement check: User=${sessionData.topicAgreed}, Partner=${sessionData.partnerTopicAgreed}`, 'info');
+            if (sessionData.topicAgreed && sessionData.partnerTopicAgreed) {
+                sendMessage({ type: 'proceedToInputs' });
+                proceedToPrivateInputs();
+            } else {
+                updateTopicAgreementStatus();
+            }
+        }
+
         async function startAINegotiation() {
             try {
                 addDebugLog('Starting AI-to-AI negotiation...', 'info');
@@ -1330,6 +1366,7 @@
                 userName: '',
                 topic: '',
                 topicAgreed: false,
+                partnerTopicAgreed: false,
                 isCreator: false,
                 connectionState: 'disconnected',
                 partnerName: null,


### PR DESCRIPTION
## Summary
- Track both local and partner topic agreements
- Delay advancing to inputs until both parties agree
- Provide status messages while awaiting partner confirmation

## Testing
- `npm test` *(fails: ENETUNREACH to OpenAI API, cannot run ai-api-interface.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a87105f3fc8330a91f8184d6904102