### PR TITLE
Add PDF export with Align Certified watermark

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Align is a web application that facilitates private negotiations between parties
 - **Zero-Knowledge Principle**: Only the final agreement is shared, private details are discarded
 - **Fair Outcomes**: AI agents work to find solutions that respect both parties' non-negotiables
 - **Transparent Process**: View insights into how the agreement was reached
+- **PDF Export**: Download the final agreement as a PDF with an Align Certified watermark (place `align-certified-watermark.png` in the project root)
 
 ## How It Works
 
@@ -75,7 +76,7 @@ The negotiation backend uses environment variables for OpenAI access:
 - Real AI integration (currently uses mock responses)
 - Multi-party negotiations
 - Agreement templates
-- Export functionality
+- Expanded export functionality
 - Mobile app version
 
 ## Contributing

--- a/index.html
+++ b/index.html
@@ -7,6 +7,8 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
     
     <style>
         body {
@@ -249,7 +251,8 @@
                     </div>
                 </div>
                 <div class="text-center mt-8 space-x-4">
-                     <button onclick="startOver()" class="bg-gray-200 text-gray-800 font-bold py-3 px-8 rounded-lg hover:bg-gray-300 transition">Start New Negotiation</button>
+                    <button id="downloadPdfBtn" class="bg-indigo-600 text-white font-bold py-3 px-8 rounded-lg hover:bg-indigo-700 transition">Download PDF</button>
+                    <button onclick="startOver()" class="bg-gray-200 text-gray-800 font-bold py-3 px-8 rounded-lg hover:bg-gray-300 transition">Start New Negotiation</button>
                 </div>
             </div>
         </div>
@@ -1316,7 +1319,37 @@
                 <p>This agreement takes effect immediately and includes a review period to ensure it works for both parties.</p>
             `;
         }
-        
+
+        async function downloadAgreementPDF() {
+            const { jsPDF } = window.jspdf;
+            const agreementCard = document.querySelector('#resultsScreen > div:first-child');
+            if (!agreementCard) return;
+
+            const canvas = await html2canvas(agreementCard, { scale: 2 });
+            const imgData = canvas.toDataURL('image/png');
+
+            const pdf = new jsPDF('p', 'pt', 'letter');
+            const pageWidth = pdf.internal.pageSize.getWidth();
+            const pageHeight = pdf.internal.pageSize.getHeight();
+
+            const watermark = new Image();
+            watermark.src = 'align-certified-watermark.png';
+            await new Promise(resolve => watermark.onload = resolve);
+            const wmWidth = pageWidth * 0.6;
+            const wmHeight = watermark.height / watermark.width * wmWidth;
+            pdf.setGState(new pdf.GState({ opacity: 0.1 }));
+            pdf.addImage(watermark, 'PNG', (pageWidth - wmWidth) / 2, (pageHeight - wmHeight) / 2, wmWidth, wmHeight);
+            pdf.setGState(new pdf.GState({ opacity: 1 }));
+
+            const imgProps = pdf.getImageProperties(imgData);
+            const ratio = Math.min(pageWidth / imgProps.width, (pageHeight - 80) / imgProps.height);
+            const pdfWidth = imgProps.width * ratio;
+            const pdfHeight = imgProps.height * ratio;
+            pdf.addImage(imgData, 'PNG', (pageWidth - pdfWidth) / 2, 40, pdfWidth, pdfHeight);
+
+            pdf.save('agreement.pdf');
+        }
+
         function startOver() {
             // Clean up polling and session data
             cleanupSession();
@@ -1358,11 +1391,13 @@
             
             // Reset URL
             window.history.pushState({}, '', window.location.pathname);
-            
+
             // Go back to login
             showScreen(loginScreen);
             updateStepIndicator(1);
         }
+
+        document.getElementById('downloadPdfBtn').addEventListener('click', downloadAgreementPDF);
 
         // Handle browser backgrounding/foregrounding (mobile and desktop)
         function handleVisibilityChange() {

--- a/simple-align.html
+++ b/simple-align.html
@@ -76,6 +76,8 @@
         .text-small { font-size: 14px; color: #64748b; }
         .mt { margin-top: 20px; }
     </style>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
 </head>
 <body>
     <div class="container">
@@ -142,6 +144,7 @@
         <div id="resultsScreen" class="card hidden">
             <h2>Proposed Agreement</h2>
             <div id="agreementResult"></div>
+            <button id="downloadPdfBtn" class="mt">Download PDF</button>
             <button onclick="startOver()" class="mt">Start New Session</button>
         </div>
 
@@ -381,6 +384,39 @@
             showScreen('agreementScreen');
         }
 
+        async function downloadAgreementPDF() {
+            const { jsPDF } = window.jspdf;
+            const temp = document.createElement('div');
+            temp.style.padding = '20px';
+            temp.innerHTML = `<h2>Proposed Agreement</h2>${document.getElementById('agreementResult').innerHTML}`;
+            document.body.appendChild(temp);
+
+            const canvas = await html2canvas(temp, { scale: 2 });
+            document.body.removeChild(temp);
+
+            const pdf = new jsPDF('p', 'pt', 'letter');
+            const pageWidth = pdf.internal.pageSize.getWidth();
+            const pageHeight = pdf.internal.pageSize.getHeight();
+
+            const watermark = new Image();
+            watermark.src = 'align-certified-watermark.png';
+            await new Promise(resolve => watermark.onload = resolve);
+            const wmWidth = pageWidth * 0.6;
+            const wmHeight = watermark.height / watermark.width * wmWidth;
+            pdf.setGState(new pdf.GState({ opacity: 0.1 }));
+            pdf.addImage(watermark, 'PNG', (pageWidth - wmWidth) / 2, (pageHeight - wmHeight) / 2, wmWidth, wmHeight);
+            pdf.setGState(new pdf.GState({ opacity: 1 }));
+
+            const imgData = canvas.toDataURL('image/png');
+            const imgProps = pdf.getImageProperties(imgData);
+            const ratio = Math.min(pageWidth / imgProps.width, (pageHeight - 80) / imgProps.height);
+            const pdfWidth = imgProps.width * ratio;
+            const pdfHeight = imgProps.height * ratio;
+            pdf.addImage(imgData, 'PNG', (pageWidth - pdfWidth) / 2, 40, pdfWidth, pdfHeight);
+
+            pdf.save('agreement.pdf');
+        }
+
         function startOver() {
             localStorage.removeItem('align_session');
             if (session.id) {
@@ -390,6 +426,8 @@
             window.history.pushState({}, '', window.location.pathname);
             location.reload();
         }
+
+        document.getElementById('downloadPdfBtn').addEventListener('click', downloadAgreementPDF);
 
         // Initialize on load
         init();


### PR DESCRIPTION
## Summary
- allow users to download the final agreement as a PDF
- include Align Certified watermark on generated PDFs (image file to be supplied separately)
- document PDF export option and update simple demo

## Testing
- `npm test` *(fails: missing `supertest` module for AI API and P2P tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a8716701788330823331cf10c59020