### PR TITLE
Enable expandable AI backchannel rounds

### DIFF
--- a/__tests__/ai-api-interface.test.js
+++ b/__tests__/ai-api-interface.test.js
@@ -161,15 +161,21 @@ describe('AI API Interface Tests', () => {
             moderator.negotiationRounds.push({
                 proposal1: 'Alice proposal',
                 proposal2: 'Bob proposal',
-                moderation: 'This is a moderator response that should be truncated because it is longer than 150 characters and we want to test the substring functionality',
+                moderation: 'Moderator response detailing the negotiation',
                 timestamp: Date.now()
             });
-            
+
             const insights = moderator.getBackchannelInsights();
-            
+
             expect(insights).toHaveLength(1);
-            expect(insights[0]).toContain('Round 1:');
-            expect(insights[0].length).toBeLessThanOrEqual(153); // "Round 1: " + 150 + "..."
+            expect(insights[0]).toEqual({
+                round: 1,
+                advocate1: 'Alice',
+                advocate2: 'Bob',
+                proposal1: 'Alice proposal',
+                proposal2: 'Bob proposal',
+                moderation: 'Moderator response detailing the negotiation'
+            });
         });
     });
     

--- a/ai-negotiation.js
+++ b/ai-negotiation.js
@@ -223,9 +223,14 @@ The agreement should be specific, fair, and implementable by both parties.`;
     }
 
     getBackchannelInsights() {
-        return this.negotiationRounds.map((round, index) =>
-            `Round ${index + 1}: ${round.moderation.substring(0, 141)}...`
-        );
+        return this.negotiationRounds.map((round, index) => ({
+            round: index + 1,
+            advocate1: this.advocate1.userName,
+            advocate2: this.advocate2.userName,
+            proposal1: round.proposal1,
+            proposal2: round.proposal2,
+            moderation: round.moderation
+        }));
     }
 }
 

--- a/index-backup.html
+++ b/index-backup.html
@@ -1371,12 +1371,25 @@
         function displayNegotiationResult(result) {
             agreementDiv.innerHTML = result.agreement;
             backchannelDiv.innerHTML = '';
-            
-            result.backchannel.forEach((item, index) => {
-                const p = document.createElement('p');
-                p.className = 'p-2 bg-gray-100 rounded-md mb-2';
-                p.innerHTML = `<i class="fas fa-check-circle text-green-500 mr-2"></i> <strong>Round ${index + 1}:</strong> ${item}`;
-                backchannelDiv.appendChild(p);
+
+            result.backchannel.forEach(item => {
+                const details = document.createElement('details');
+                details.className = 'p-2 bg-gray-100 rounded-md mb-2';
+
+                const summary = document.createElement('summary');
+                summary.innerHTML = `<i class="fas fa-comments text-indigo-600 mr-2"></i> <strong>Round ${item.round}</strong>`;
+                details.appendChild(summary);
+
+                const content = document.createElement('div');
+                content.className = 'mt-2 space-y-1';
+                content.innerHTML = `
+                    <p><strong>${item.advocate1}:</strong> ${item.proposal1}</p>
+                    <p><strong>${item.advocate2}:</strong> ${item.proposal2}</p>
+                    <p><strong>Moderator:</strong> ${item.moderation}</p>
+                `;
+                details.appendChild(content);
+
+                backchannelDiv.appendChild(details);
             });
 
             // Transition to results screen
@@ -1400,11 +1413,46 @@
             const mockResult = {
                 agreement: generateMockAgreement(topic, userInputs, partnerData),
                 backchannel: [
-                    "Identified both parties' core needs and constraints",
-                    "Found areas of potential compromise and mutual benefit",
-                    "Developed a time-sharing solution that respects both schedules",
-                    "Ensured fairness and equal distribution of responsibilities",
-                    "Confirmed all non-negotiable requirements are met"
+                    {
+                        round: 1,
+                        advocate1: 'Advocate 1',
+                        advocate2: 'Advocate 2',
+                        proposal1: 'Outlined core needs',
+                        proposal2: 'Outlined core needs',
+                        moderation: "Identified both parties' core needs and constraints"
+                    },
+                    {
+                        round: 2,
+                        advocate1: 'Advocate 1',
+                        advocate2: 'Advocate 2',
+                        proposal1: 'Proposed compromise',
+                        proposal2: 'Provided counter-offer',
+                        moderation: 'Found areas of potential compromise and mutual benefit'
+                    },
+                    {
+                        round: 3,
+                        advocate1: 'Advocate 1',
+                        advocate2: 'Advocate 2',
+                        proposal1: 'Suggested schedule',
+                        proposal2: 'Adjusted schedule',
+                        moderation: 'Developed a time-sharing solution that respects both schedules'
+                    },
+                    {
+                        round: 4,
+                        advocate1: 'Advocate 1',
+                        advocate2: 'Advocate 2',
+                        proposal1: 'Ensured fairness',
+                        proposal2: 'Agreed on fairness',
+                        moderation: 'Ensured fairness and equal distribution of responsibilities'
+                    },
+                    {
+                        round: 5,
+                        advocate1: 'Advocate 1',
+                        advocate2: 'Advocate 2',
+                        proposal1: 'Confirmed requirements',
+                        proposal2: 'Confirmed requirements',
+                        moderation: 'Confirmed all non-negotiable requirements are met'
+                    }
                 ]
             };
             

--- a/index.html
+++ b/index.html
@@ -1283,12 +1283,25 @@
         function displayNegotiationResult(result) {
             agreementDiv.innerHTML = result.agreement;
             backchannelDiv.innerHTML = '';
-            
-            result.backchannel.forEach((item, index) => {
-                const p = document.createElement('p');
-                p.className = 'p-2 bg-gray-100 rounded-md mb-2';
-                p.innerHTML = `<i class="fas fa-check-circle text-green-500 mr-2"></i> <strong>Round ${index + 1}:</strong> ${item}`;
-                backchannelDiv.appendChild(p);
+
+            result.backchannel.forEach(item => {
+                const details = document.createElement('details');
+                details.className = 'p-2 bg-gray-100 rounded-md mb-2';
+
+                const summary = document.createElement('summary');
+                summary.innerHTML = `<i class="fas fa-comments text-indigo-600 mr-2"></i> <strong>Round ${item.round}</strong>`;
+                details.appendChild(summary);
+
+                const content = document.createElement('div');
+                content.className = 'mt-2 space-y-1';
+                content.innerHTML = `
+                    <p><strong>${item.advocate1}:</strong> ${item.proposal1}</p>
+                    <p><strong>${item.advocate2}:</strong> ${item.proposal2}</p>
+                    <p><strong>Moderator:</strong> ${item.moderation}</p>
+                `;
+                details.appendChild(content);
+
+                backchannelDiv.appendChild(details);
             });
 
             // Transition to results screen
@@ -1312,11 +1325,46 @@
             const mockResult = {
                 agreement: generateMockAgreement(topic, userInputs, partnerData),
                 backchannel: [
-                    "Identified both parties' core needs and constraints",
-                    "Found areas of potential compromise and mutual benefit",
-                    "Developed a time-sharing solution that respects both schedules",
-                    "Ensured fairness and equal distribution of responsibilities",
-                    "Confirmed all non-negotiable requirements are met"
+                    {
+                        round: 1,
+                        advocate1: 'Advocate 1',
+                        advocate2: 'Advocate 2',
+                        proposal1: 'Outlined core needs',
+                        proposal2: 'Outlined core needs',
+                        moderation: "Identified both parties' core needs and constraints"
+                    },
+                    {
+                        round: 2,
+                        advocate1: 'Advocate 1',
+                        advocate2: 'Advocate 2',
+                        proposal1: 'Proposed compromise',
+                        proposal2: 'Provided counter-offer',
+                        moderation: 'Found areas of potential compromise and mutual benefit'
+                    },
+                    {
+                        round: 3,
+                        advocate1: 'Advocate 1',
+                        advocate2: 'Advocate 2',
+                        proposal1: 'Suggested schedule',
+                        proposal2: 'Adjusted schedule',
+                        moderation: 'Developed a time-sharing solution that respects both schedules'
+                    },
+                    {
+                        round: 4,
+                        advocate1: 'Advocate 1',
+                        advocate2: 'Advocate 2',
+                        proposal1: 'Ensured fairness',
+                        proposal2: 'Agreed on fairness',
+                        moderation: 'Ensured fairness and equal distribution of responsibilities'
+                    },
+                    {
+                        round: 5,
+                        advocate1: 'Advocate 1',
+                        advocate2: 'Advocate 2',
+                        proposal1: 'Confirmed requirements',
+                        proposal2: 'Confirmed requirements',
+                        moderation: 'Confirmed all non-negotiable requirements are met'
+                    }
                 ]
             };
             


### PR DESCRIPTION
## Summary
- Return full proposal and moderation details for each round from the API
- Show expandable backchannel rounds revealing AI proposals and moderator commentary
- Align mock data and tests with the new structured insights

## Testing
- `npm test` *(fails: Exceeded timeout of 5000 ms for a hook while waiting for `done()` to be called in p2p-communication.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a874c2fdf88330a03655b631cad4ab