### PR TITLE
Prevent mobile keyboards from hiding focused inputs

### DIFF
--- a/index.html
+++ b/index.html
@@ -1716,6 +1716,16 @@
             });
         }
 
+        // Ensure focused inputs stay visible on mobile when the keyboard opens
+        document.querySelectorAll('input, textarea').forEach((el) => {
+            el.addEventListener('focus', () => {
+                // Delay scrolling to allow the keyboard to appear
+                setTimeout(() => {
+                    el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                }, 300);
+            });
+        });
+
     </script>
 </body>
 </html>

--- a/simple-align.html
+++ b/simple-align.html
@@ -431,6 +431,15 @@
 
         // Initialize on load
         init();
+
+        // Keep focused inputs visible on mobile when the on-screen keyboard appears
+        document.querySelectorAll('input, textarea').forEach((el) => {
+            el.addEventListener('focus', () => {
+                setTimeout(() => {
+                    el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                }, 300);
+            });
+        });
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Keep text fields visible when the mobile on-screen keyboard opens by scrolling focused inputs into view.
- Apply this behavior across main and simple interfaces.

## Testing
- `npm test` *(fails: WebSocket is not open: readyState 0 (CONNECTING))*

------
https://chatgpt.com/codex/tasks/task_e_68a87685137c83309280623e51c42437