### PR TITLE
feat: display app version on all pages

### DIFF
--- a/index-backup.html
+++ b/index-backup.html
@@ -1578,5 +1578,6 @@
         }
 
     </script>
+    <script src="version.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1669,5 +1669,6 @@
         }
 
     </script>
+    <script src="version.js"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "align-ai-moderator",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A private, fair way to find agreement through AI-to-AI moderated negotiations",
   "main": "server.js",
   "scripts": {

--- a/simple-align.html
+++ b/simple-align.html
@@ -432,5 +432,6 @@
         // Initialize on load
         init();
     </script>
+    <script src="version.js"></script>
 </body>
 </html>

--- a/version.js
+++ b/version.js
@@ -1,0 +1,20 @@
+(function() {
+  const version = '1.0.1';
+  window.APP_VERSION = version;
+  function appendVersion() {
+    const el = document.createElement('div');
+    el.textContent = `v${version}`;
+    el.style.position = 'fixed';
+    el.style.bottom = '10px';
+    el.style.right = '10px';
+    el.style.fontSize = '12px';
+    el.style.color = '#64748b';
+    el.style.fontFamily = 'Inter, sans-serif';
+    document.body.appendChild(el);
+  }
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', appendVersion);
+  } else {
+    appendVersion();
+  }
+})();


### PR DESCRIPTION
## Summary
- show app version via new `version.js` script at bottom-right of each page
- bump package.json version to 1.0.1

## Testing
- `npm test` *(fails: Exceeded timeout of 5000 ms for a hook while waiting for `done()` to be called)*

------
https://chatgpt.com/codex/tasks/task_e_68a876079a0c8330ad70d82e9082d242